### PR TITLE
feat: add singleton storage.

### DIFF
--- a/source/libs/storage/index.ts
+++ b/source/libs/storage/index.ts
@@ -1,0 +1,60 @@
+import {browser} from 'webextension-polyfill-ts';
+
+export class BrowserStorage {
+  private static instance: BrowserStorage;
+
+  private followers: string[];
+
+  constructor(followers: string[]) {
+    this.followers = followers;
+  }
+
+  /**
+   * getStorage returns the instance, which is
+   * the singleton instance.
+   * @returns BrowserStorage
+   */
+  static async getStorage(): Promise<BrowserStorage> {
+    if (BrowserStorage.instance) {
+      return BrowserStorage.instance;
+    }
+
+    let {followers} = await browser.storage.sync.get('followers');
+    if (followers === undefined) {
+      followers = [];
+    }
+
+    BrowserStorage.instance = new BrowserStorage(followers);
+    return BrowserStorage.instance;
+  }
+
+  /**
+   * list returns followers.
+   * @returns followers
+   */
+  list(): string[] {
+    return this.followers;
+  }
+
+  /**
+   * add a new follower, and
+   * sync followers with Chrome.
+   * @param name The follower name to store.
+   */
+  add(name: string): void {
+    this.followers.push(name);
+    browser.storage.sync.set({followers: this.followers});
+  }
+
+  /**
+   * remove the follower, and
+   * sync followers with Chrome.
+   * @param name
+   */
+  remove(name: string): void {
+    this.followers = this.followers.filter((candidate: string) => {
+      return candidate !== name;
+    });
+    browser.storage.sync.set({followers: this.followers});
+  }
+}


### PR DESCRIPTION
## 설명

팔로워를 저장하기 위해서 브라우져(browser) 스토리지를 이용했습니다. 이를 구현하는데 있어서 Singleton 패턴을 이용해서 한 곳에서만 데이터를 읽고 쓸 수 있도록 하였습니다.  

## 사용법 

```tsx
// in React
async componentDidMount() {
  const storage = await BrowserStorage.getStorage();
  this.storage = storage
}
```

## 참고

* [Chrome Storage](https://developer.chrome.com/docs/extensions/reference/storage/)
* [Typescript Singleton](https://refactoring.guru/design-patterns/singleton/typescript/example)